### PR TITLE
Fixed date bug in goal edit

### DIFF
--- a/code/TimeManagementApp/pages/goals/editGoal.js
+++ b/code/TimeManagementApp/pages/goals/editGoal.js
@@ -33,7 +33,7 @@ export default function editGoal({ route, navigation }) {
   const goal = JSON.parse(route.params.goal);
   const [name, setName] = useState(goal.name);
   const [description, setDescription] = useState(goal.description);
-  const [date, setDate] = useState(goal.date);
+  const [date, setDate] = useState(new Date(goal.date));
   const [checklist, setChecklist] = useState(goal.checklist)
   // Initially the user is only viewing the goal
   const [editGoal, setEdit] = useState(false);


### PR DESCRIPTION
The issue was caused by the goal object being parsed as a string in the params to the editGoal page. Forgot to convert it back into a Date object. Create a Date object from the parsed date string fixed this issue.